### PR TITLE
docs: fix receive typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## About
-☎️ Pyckup is a Python package used to make and recieve calls and have them conducted by AI.  
+☎️ Pyckup is a Python package used to make and receive calls and have them conducted by AI.
 🔧 Can be used to build all kinds of realtime applications that work over the telephone network, including ones with complex conversational flows.  
 📖 It's like [Bland](https://www.bland.ai/) or [Synthflow](https://synthflow.ai/), but Open Source.  
 ⚙️ Conversations can be defined by providing a YAML conversation configuration file (you can imagine the agent following a flowchart of conversation items that you specify). See annotated example in samples/sample_conversation_config.yaml.  

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 # About
-☎️ Pyckup is a Python package used to make and recieve calls and have them conducted by AI.  
+☎️ Pyckup is a Python package used to make and receive calls and have them conducted by AI.
 🔧 Can be used to build all kinds of realtime applications that work over the telephone network, including ones with complex conversational flows.  
 📖 It's like [Bland](https://www.bland.ai/) or [Synthflow](https://synthflow.ai/), but Open Source.  
 ⚙️ Conversations can be defined by providing a YAML conversation configuration file (you can imagine the agent following a flowchart of conversation items that you specify). See annotated example in samples/sample_conversation_config.yaml.  

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -64,7 +64,7 @@ from pyckup_core.pyckup import Pyckup
 pu = Pyckup("sip_credentials.json")
 
 grp = pu.start_listening(ConversationConfig.from_yaml("hello_world_config.yaml"))
-# calls can be recieved during this time
+# calls can be received during this time
 input()
 pu.stop_listening(grp)
 ```


### PR DESCRIPTION
## Problem
The README and docs contain visible spelling typos around making/receiving AI phone calls.

## Solution
Corrected `recieve`/`recieved` to `receive`/`received` in the README and docs pages.

## Validation
- Ran `git diff --check`

Category: docs/typo
Confidence score: 85/100